### PR TITLE
GHA: check if version number has incremented, auto-increment dates

### DIFF
--- a/.github/workflows/readme_sthlp.yml
+++ b/.github/workflows/readme_sthlp.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
-    - 'calipmatch.sthlp'
+      - 'calipmatch.sthlp'
   workflow_dispatch:
 
 jobs:
@@ -18,11 +18,11 @@ jobs:
       #######################
 
       - name: Check out code repository (main branch)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         if: github.ref == 'refs/heads/main'
 
       - name: Check out code repository (PR branch)
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
         if: github.ref != 'refs/heads/main'

--- a/.github/workflows/stata_tests.yml
+++ b/.github/workflows/stata_tests.yml
@@ -16,7 +16,7 @@ jobs:
       #######################
 
       - name: Check out code repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install Stata
         run: ./automation/install_stata.sh

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'\2/' calipmatch.ado
+            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'/' calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'\2/' calipmatch.sthlp
+            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'/' calipmatch.sthlp
           fi
           git diff
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.ado
+            sed -iE '1s/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.sthlp
+            sed -iE '2s/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.sthlp
           fi
           git diff
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -60,13 +60,13 @@ jobs:
         run: |
           for b in "pr" "main"; do
             v=${b}_ado_version
-            ${b}_major=$(echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
-            ${b}_minor=$(echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
-            ${b}_patch=$(echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')
             echo ${b}
             echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p'
             echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p'
             echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p'
+            printf -v "${b}_major" "%s" "$(echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')"
+            printf -v "${b}_minor" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')"
+            printf -v "${b}_patch" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')"
           done
           if [[ ! $pr_major -gt $main_major ]] && [[ ! $pr_minor -gt $main_minor ]] && [[ ! $pr_minor -gt $main_minor ]]; then
             echo "version number not incremented, pr=${pr_ado_version} main=${main_ado_version}"

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -32,18 +32,21 @@ jobs:
           ref: main
           path: main
 
-      #######################
-      # ado-file version
-      #######################
-
       - name: Obtain ado-file 'version number' and 'changed date' from each branch
         run: |
           for b in "pr" "main"; do
             cd ${b}
             echo "${b}_ado_version=$(head -n 1 calipmatch.ado | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
             echo "${b}_ado_date=$(head -n 1 calipmatch.ado | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
+
+            echo "${b}_help_version=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
+            echo "${b}_help_date=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
             cd ..
           done
+
+      #######################
+      # Version numbers
+      #######################
 
       - name: Validate ado-file version numbers exist
         run: |
@@ -56,36 +59,6 @@ jobs:
             exit 1
           fi
 
-      - name: Validate ado-file version numbers are incremented
-        run: |
-          for b in "pr" "main"; do
-            v=${b}_ado_version
-            echo ${b}
-            echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p'
-            echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p'
-            echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p'
-            printf -v "${b}_major" "%s" "$(echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')"
-            printf -v "${b}_minor" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')"
-            printf -v "${b}_patch" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')"
-          done
-          if [[ ! $pr_major -gt $main_major ]] && [[ ! $pr_minor -gt $main_minor ]] && [[ ! $pr_minor -gt $main_minor ]]; then
-            echo "version number not incremented, pr=${pr_ado_version} main=${main_ado_version}"
-            exit 1
-          fi
-
-      #######################
-      # help-file version
-      #######################
-
-      - name: Obtain help-file 'version number' and 'changed date' from each branch
-        run: |
-          for b in "pr" "main"; do
-            cd ${b}
-            echo "${b}_help_version=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
-            echo "${b}_help_date=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
-            cd ..
-          done
-
       - name: Validate help-file version numbers exist
         run: |
           if [[ -z ${pr_help_version} ]]; then
@@ -94,6 +67,19 @@ jobs:
           fi
           if [[ -z ${main_help_version} ]]; then
             echo "main branch: version number not detected in calipmatch.sthlp"
+            exit 1
+          fi
+
+      - name: Validate ado-file version numbers are incremented
+        run: |
+          for b in "pr" "main"; do
+            v=${b}_ado_version
+            printf -v "${b}_major" "%s" "$(echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')"
+            printf -v "${b}_minor" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')"
+            printf -v "${b}_patch" "%s" "$(echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')"
+          done
+          if [[ ! $pr_major -gt $main_major ]] && [[ ! $pr_minor -gt $main_minor ]] && [[ ! $pr_minor -gt $main_minor ]]; then
+            echo "version number not incremented, pr=${pr_ado_version} main=${main_ado_version}"
             exit 1
           fi
 
@@ -108,3 +94,19 @@ jobs:
             echo "version numbers in calipmatch.ado and calipmatch.sthlp do not match, ado=${main_ado_version} sthlp=${main_help_version}"
             exit 1
           fi
+
+      #######################
+      # Date last updated
+      #######################
+
+      - name: Update date in ado-file and help-file
+        run: |
+          today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
+          if [[ "$pr_ado_date" != "$today" ]]; then
+            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'\2/' calipmatch.ado
+          fi
+          if [[ "$pr_help_date" != "$today" ]]; then
+            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'\2/' calipmatch.sthlp
+          fi
+          git diff
+        working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -102,37 +102,39 @@ jobs:
       - name: Update date in ado-file and help-file
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
-
-          head -n 2 calipmatch.ado
-          echo ""
-          head -n 2 calipmatch.sthlp
-          echo ""
-
           if [[ "$pr_ado_date" != "$today" ]]; then
             sed -iE "1s/${pr_ado_date}/${today}/" calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
             sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
-
-          head -n 2 calipmatch.ado
-          echo ""
-          head -n 2 calipmatch.sthlp
-          echo ""
         working-directory: pr
 
       - name: Update date in package-file
         run: |
-          head -n 20 calipmatch.pkg | tail -n 5
-          echo ""
-
           if grep -q '^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]' calipmatch.pkg; then
             sed -iE "s/^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]/d Distribution-Date: $(TZ=America/New_York date +%Y%m%d)/" calipmatch.pkg
           else
             echo "PR branch: Distribution-Date not detected in calipmatch.pkg"
             exit 1
           fi
-          
-          head -n 20 calipmatch.pkg | tail -n 5
-          echo ""
         working-directory: pr
+
+      #######################
+      # Push
+      #######################
+
+      - name: Check if there are changes
+        run: |
+          set +e
+          test -z "$(git status --porcelain)"
+          echo "FILES_UPDATED=$?" >> $GITHUB_ENV
+
+      - name: Push updates to Github
+        run: |
+          git config user.name OppInsights-Bot
+          git config user.email info@opportunityinsights.org
+          git add calipmatch.ado calipmatch.sthlp calipmatch.pkg
+          git commit -m "Update 'last updated' dates"
+          git push
+        if: env.FILES_UPDATED == 1

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -118,8 +118,8 @@ jobs:
           if [[ "$pr_help_date" != "$today" ]]; then
             sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
-          if [[ "$pr_pkg_date" != "$today" ]]; then
-            sed -iE "${date_line}s/${pr_pkg_date}/${today}/" calipmatch.pkg
+          if [[ "$pr_pkg_date" != "$today_pkgfmt" ]]; then
+            sed -iE "${date_line}s/${pr_pkg_date}/${today_pkgfmt}/" calipmatch.pkg
           fi
 
           head -n 2 calipmatch.ado

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -125,5 +125,6 @@ jobs:
           head -n 2 calipmatch.ado
           echo ""
           head -n 2 calipmatch.sthlp
-          sed "${date_line}q;d" file.txt
+          echo ""
+          sed "${date_line}q;d" calipmatch.pkg
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -59,13 +59,14 @@ jobs:
       - name: Validate ado-file version numbers are incremented
         run: |
           for b in "pr" "main"; do
-            ${b}_major=$(echo "${${b}_ado_version}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
-            ${b}_minor=$(echo "${${b}_ado_version}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
-            ${b}_patch=$(echo "${${b}_ado_version}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')
+            v=${b}_ado_version
+            ${b}_major=$(echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
+            ${b}_minor=$(echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
+            ${b}_patch=$(echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')
             echo ${b}
-            echo ${${b}_major}
-            echo ${${b}_minor}
-            echo ${${b}_patch}
+            echo "${!v}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p'
+            echo "${!v}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p'
+            echo "${!v}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p'
           done
           if [[ ! $pr_major -gt $main_major ]] && [[ ! $pr_minor -gt $main_minor ]] && [[ ! $pr_minor -gt $main_minor ]]; then
             echo "version number not incremented, pr=${pr_ado_version} main=${main_ado_version}"

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -99,17 +99,13 @@ jobs:
       # Date last updated
       #######################
 
-      - name: Update date in ado-file, help-file and package-file
+      - name: Update date in ado-file and help-file
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
-          today_pkgfmt=$(TZ=America/New_York date +%Y%-m%d)
+
           head -n 2 calipmatch.ado
           echo ""
           head -n 2 calipmatch.sthlp
-          echo ""
-          date_line=$(sed -n '/Distribution-Date:/=' calipmatch.pkg)
-          pr_pkg_date=$(sed "${date_line}q;d" calipmatch.pkg | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
-          echo "$pr_pkg_date"
           echo ""
 
           if [[ "$pr_ado_date" != "$today" ]]; then
@@ -118,13 +114,32 @@ jobs:
           if [[ "$pr_help_date" != "$today" ]]; then
             sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
-          if [[ "$pr_pkg_date" != "$today_pkgfmt" ]]; then
-            sed -iE "${date_line}s/${pr_pkg_date}/${today_pkgfmt}/" calipmatch.pkg
-          fi
 
           head -n 2 calipmatch.ado
           echo ""
           head -n 2 calipmatch.sthlp
           echo ""
+        working-directory: pr
+
+      - name: Update date in package-file
+        run: |
+          today_pkgfmt=$(TZ=America/New_York date +%Y%-m%d)
+
+          head -n 20 calipmatch.pkg | tail -n 5
+          echo ""
+
+          date_line=$(sed -n '/Distribution-Date:/=' calipmatch.pkg)
+          pr_pkg_date=$(sed "${date_line}q;d" calipmatch.pkg | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
+          echo "$pr_pkg_date"
+          echo ""
+
+          if [[ "$pr_pkg_date" != "$today_pkgfmt" ]]; then
+            sed -iE "${date_line}s/${pr_pkg_date}/${today_pkgfmt}/" calipmatch.pkg
+          fi
+
           sed "${date_line}q;d" calipmatch.pkg
+          echo ""
+
+          head -n 20 calipmatch.pkg | tail -n 5
+          echo ""
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -24,13 +24,13 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
-          path: repo_pr
+          path: pr
 
       - name: Check out repository, main branch
         uses: actions/checkout@v3
         with:
           ref: main
-          path: repo_main
+          path: main
 
       #######################
       # ado-file version

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -21,7 +21,7 @@ jobs:
       # Configure
       #######################
 
-      - name: Check out code repository, PR branch
+      - name: Check out repository, PR branch
         uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.ref }}
@@ -33,7 +33,7 @@ jobs:
           ref: main
           path: main
 
-      - name: Obtain ado-file 'version number' and 'changed date' from each branch
+      - name: Obtain 'version number' and 'changed date' from ado-file and help-file
         run: |
           for b in "pr" "main"; do
             cd ${b}
@@ -84,7 +84,7 @@ jobs:
             exit 1
           fi
 
-      - name: Validate help-file version numbers are match ado-file version numbers
+      - name: Validate help-file version numbers match ado-file version numbers
         run: |
           if [[ "$pr_ado_version" != "$pr_help_version" ]]; then
             echo "version numbers in calipmatch.ado and calipmatch.sthlp do not match, ado=${pr_ado_version} sthlp=${pr_help_version}"

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -41,7 +41,7 @@ jobs:
           for b in "pr" "main"; do
             cd ${b}
             echo "${b}_ado_version=$(head -n 1 calipmatch.ado | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
-            echo "${b}_ado_date=$(head -n 1 calipmatch.ado | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3][0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
+            echo "${b}_ado_date=$(head -n 1 calipmatch.ado | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
             cd ..
           done
 
@@ -82,7 +82,7 @@ jobs:
           for b in "pr" "main"; do
             cd ${b}
             echo "${b}_help_version=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
-            echo "${b}_help_date=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3][0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
+            echo "${b}_help_date=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
             cd ..
           done
 

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -1,0 +1,107 @@
+name: version_increment
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+    paths:
+      - 'calipmatch.ado'
+      - 'calipmatch.sthlp'
+  workflow_dispatch:
+
+jobs:
+  version_increment:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30 # change max time from default 6hr
+
+    steps:
+      #######################
+      # Configure
+      #######################
+
+      - name: Check out code repository, PR branch
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          path: repo_pr
+
+      - name: Check out repository, main branch
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          path: repo_main
+
+      #######################
+      # ado-file version
+      #######################
+
+      - name: Obtain ado-file 'version number' and 'changed date' from each branch
+        run: |
+          for b in "pr" "main"; do
+            cd ${b}
+            echo "${b}_ado_version=$(head -n 1 calipmatch.ado | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
+            echo "${b}_ado_date=$(head -n 1 calipmatch.ado | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3][0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
+            cd ..
+          done
+
+      - name: Validate ado-file version numbers exist
+        run: |
+          if [[ -z ${pr_ado_version} ]]; then
+            echo "PR branch: version number not detected in calipmatch.ado"
+            exit 1
+          fi
+          if [[ -z ${main_ado_version} ]]; then
+            echo "main branch: version number not detected in calipmatch.ado"
+            exit 1
+          fi
+
+      - name: Validate ado-file version numbers are incremented
+          for b in "pr" "main"; do
+            ${b}_major=$(echo "${${b}_ado_version}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
+            ${b}_minor=$(echo "${${b}_ado_version}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
+            ${b}_patch=$(echo "${${b}_ado_version}" | sed -nE 's/[0-9]+\.[0-9]+\.([0-9]+)/\1/p')
+            echo ${b}
+            echo ${${b}_major}
+            echo ${${b}_minor}
+            echo ${${b}_patch}
+          done
+          if [[ ! $pr_major -gt $main_major ]] && [[ ! $pr_minor -gt $main_minor ]] && [[ ! $pr_minor -gt $main_minor ]]; then
+            echo "version number not incremented, pr=${pr_ado_version} main=${main_ado_version}"
+            exit 1
+          fi
+
+      #######################
+      # help-file version
+      #######################
+
+      - name: Obtain help-file 'version number' and 'changed date' from each branch
+        run: |
+          for b in "pr" "main"; do
+            cd ${b}
+            echo "${b}_help_version=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p')" >> $GITHUB_ENV
+            echo "${b}_help_date=$(sed '2q;d' calipmatch.sthlp | sed -nE 's/.*version [0-9]+\.[0-9]+\.[0-9]+ +([0-3][0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]).*/\1/p')" >> $GITHUB_ENV
+            cd ..
+          done
+
+      - name: Validate help-file version numbers exist
+        run: |
+          if [[ -z ${pr_help_version} ]]; then
+            echo "PR branch: version number not detected in calipmatch.sthlp"
+            exit 1
+          fi
+          if [[ -z ${main_help_version} ]]; then
+            echo "main branch: version number not detected in calipmatch.sthlp"
+            exit 1
+          fi
+
+      - name: Validate help-file version numbers are match ado-file version numbers
+          if [[ "$pr_ado_version" != "$pr_help_version" ]]; then
+            echo "version numbers in calipmatch.ado and calipmatch.sthlp do not match, ado=${pr_ado_version} sthlp=${pr_help_version}"
+            exit 1
+          fi
+          if [[ "$main_ado_version" != "$main_help_version" ]]; then
+            echo 'error in main branch:'
+            echo "version numbers in calipmatch.ado and calipmatch.sthlp do not match, ado=${main_ado_version} sthlp=${main_help_version}"
+            exit 1
+          fi

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -8,6 +8,7 @@ on:
     paths:
       - 'calipmatch.ado'
       - 'calipmatch.sthlp'
+      - 'calipmatch.pkg'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'/' calipmatch.ado
+            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/\1'"${today}"'/' calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE 's/^(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)$/\1'"${today}"'/' calipmatch.sthlp
+            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/\1'"${today}"'/' calipmatch.sthlp
           fi
           git diff
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -123,23 +123,16 @@ jobs:
 
       - name: Update date in package-file
         run: |
-          today_pkgfmt=$(TZ=America/New_York date +%Y%-m%d)
-
           head -n 20 calipmatch.pkg | tail -n 5
           echo ""
 
-          date_line=$(sed -n '/Distribution-Date:/=' calipmatch.pkg)
-          pr_pkg_date=$(sed "${date_line}q;d" calipmatch.pkg | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
-          echo "$pr_pkg_date"
-          echo ""
-
-          if [[ "$pr_pkg_date" != "$today_pkgfmt" ]]; then
-            sed -iE "${date_line}s/${pr_pkg_date}/${today_pkgfmt}/" calipmatch.pkg
+          if grep -q '^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]' calipmatch.pkg; then
+            sed -iE "s/^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]/d Distribution-Date: $(TZ=America/New_York date +%Y%m%d)/" calipmatch.pkg
+          else
+            echo "PR branch: Distribution-Date not detected in calipmatch.pkg"
+            exit 1
           fi
-
-          sed "${date_line}q;d" calipmatch.pkg
-          echo ""
-
+          
           head -n 20 calipmatch.pkg | tail -n 5
           echo ""
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -129,6 +129,7 @@ jobs:
           set +e
           test -z "$(git status --porcelain)"
           echo "FILES_UPDATED=$?" >> $GITHUB_ENV
+        working-directory: pr
 
       - name: Push updates to Github
         run: |
@@ -138,3 +139,4 @@ jobs:
           git commit -m "Update 'last updated' dates"
           git push
         if: env.FILES_UPDATED == 1
+        working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -108,10 +108,10 @@ jobs:
           echo ""
 
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE "1s/[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]/${today}/" calipmatch.ado
+            sed -iE "1s/${pr_ado_date}/${today}/" calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE "2s/[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]/${today}/" calipmatch.sthlp
+            sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
 
           head -n 2 calipmatch.ado

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -102,11 +102,19 @@ jobs:
       - name: Update date in ado-file and help-file
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
+          head -n 2 calipmatch.ado
+          echo ""
+          head -n 2 calipmatch.sthlp
+          echo ""
+
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE '1s/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.ado
+            sed -iE "1s/[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]/${today}/" calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE '2s/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.sthlp
+            sed -iE "2s/[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9]/${today}/" calipmatch.sthlp
           fi
-          git diff
+
+          head -n 2 calipmatch.ado
+          echo ""
+          head -n 2 calipmatch.sthlp
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -99,12 +99,17 @@ jobs:
       # Date last updated
       #######################
 
-      - name: Update date in ado-file and help-file
+      - name: Update date in ado-file, help-file and package-file
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
+          today_pkgfmt=$(TZ=America/New_York date +%Y%-m%d)
           head -n 2 calipmatch.ado
           echo ""
           head -n 2 calipmatch.sthlp
+          echo ""
+          date_line=$(sed -n '/Distribution-Date:/=' file.txt)
+          pr_pkg_date=$(sed "${date_line}q;d" file.txt | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
+          echo "$pr_pkg_date"
           echo ""
 
           if [[ "$pr_ado_date" != "$today" ]]; then
@@ -113,8 +118,12 @@ jobs:
           if [[ "$pr_help_date" != "$today" ]]; then
             sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
+          if [[ "$pr_pkg_date" != "$today" ]]; then
+            sed -iE "${date_line}s/${pr_pkg_date}/${today}/" file.txt
+          fi
 
           head -n 2 calipmatch.ado
           echo ""
           head -n 2 calipmatch.sthlp
+          sed "${date_line}q;d" file.txt
         working-directory: pr

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -107,8 +107,8 @@ jobs:
           echo ""
           head -n 2 calipmatch.sthlp
           echo ""
-          date_line=$(sed -n '/Distribution-Date:/=' file.txt)
-          pr_pkg_date=$(sed "${date_line}q;d" file.txt | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
+          date_line=$(sed -n '/Distribution-Date:/=' calipmatch.pkg)
+          pr_pkg_date=$(sed "${date_line}q;d" calipmatch.pkg | sed -nE 's/.*Distribution-Date: ([0-3][0-9][0-9][0-9][0-1][0-9][0-3][0-9]).*/\1/p')
           echo "$pr_pkg_date"
           echo ""
 
@@ -119,7 +119,7 @@ jobs:
             sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
           if [[ "$pr_pkg_date" != "$today" ]]; then
-            sed -iE "${date_line}s/${pr_pkg_date}/${today}/" file.txt
+            sed -iE "${date_line}s/${pr_pkg_date}/${today}/" calipmatch.pkg
           fi
 
           head -n 2 calipmatch.ado

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -57,6 +57,7 @@ jobs:
           fi
 
       - name: Validate ado-file version numbers are incremented
+        run: |
           for b in "pr" "main"; do
             ${b}_major=$(echo "${${b}_ado_version}" | sed -nE 's/([0-9]+)\.[0-9]+\.[0-9]+/\1/p')
             ${b}_minor=$(echo "${${b}_ado_version}" | sed -nE 's/[0-9]+\.([0-9]+)\.[0-9]+/\1/p')
@@ -96,6 +97,7 @@ jobs:
           fi
 
       - name: Validate help-file version numbers are match ado-file version numbers
+        run: |
           if [[ "$pr_ado_version" != "$pr_help_version" ]]; then
             echo "version numbers in calipmatch.ado and calipmatch.sthlp do not match, ado=${pr_ado_version} sthlp=${pr_help_version}"
             exit 1

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -104,17 +104,17 @@ jobs:
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE "1s/${pr_ado_date}/${today}/" calipmatch.ado
+            sed -i "1s/${pr_ado_date}/${today}/" calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE "2s/${pr_help_date}/${today}/" calipmatch.sthlp
+            sed -i "2s/${pr_help_date}/${today}/" calipmatch.sthlp
           fi
         working-directory: pr
 
       - name: Update date in package-file
         run: |
           if grep -q '^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]' calipmatch.pkg; then
-            sed -iE "s/^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]/d Distribution-Date: $(TZ=America/New_York date +%Y%m%d)/" calipmatch.pkg
+            sed -i "s/^d Distribution-Date: [0-9][0-9][0-9][0-9][0-1][0-9][0-3][0-9]/d Distribution-Date: $(TZ=America/New_York date +%Y%m%d)/" calipmatch.pkg
           else
             echo "PR branch: Distribution-Date not detected in calipmatch.pkg"
             exit 1

--- a/.github/workflows/version_increment.yml
+++ b/.github/workflows/version_increment.yml
@@ -103,10 +103,10 @@ jobs:
         run: |
           today=$(TZ=America/New_York date +%-d%b%Y | tr A-Z a-z)
           if [[ "$pr_ado_date" != "$today" ]]; then
-            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/\1'"${today}"'/' calipmatch.ado
+            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.ado
           fi
           if [[ "$pr_help_date" != "$today" ]]; then
-            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/\1'"${today}"'/' calipmatch.sthlp
+            sed -iE 's/(.*version [0-9]+\.[0-9]+\.[0-9]+ +)[0-3]?[0-9][a-z][a-z][a-z][0-9][0-9][0-9][0-9](.*)/'"${today}"'/' calipmatch.sthlp
           fi
           git diff
         working-directory: pr

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -1,4 +1,4 @@
-*! version 1.1.0  10jun2022  Michael Stepner and Allan Garland, software@michaelstepner.com
+*! version 1.1.0  26oct2022  Michael Stepner and Allan Garland, software@michaelstepner.com
 
 /* CC0 license information:
 To the extent possible under law, the author has dedicated all copyright and related and neighboring rights

--- a/calipmatch.pkg
+++ b/calipmatch.pkg
@@ -14,7 +14,7 @@ d KW: caliper
 d
 d Requires: Stata version 13 
 d
-d Distribution-Date: 20220610
+d Distribution-Date: 20221026
 d
 d Author: Michael Stepner
 d Support: email software@michaelstepner.com

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -1,5 +1,5 @@
 {smcl}
-{* *! version 1.1.0  10jun2022}{...}
+{* *! version 1.1.0  26oct2022}{...}
 {viewerjumpto "Syntax" "calipmatch##syntax"}{...}
 {viewerjumpto "Description" "calipmatch##description"}{...}
 {viewerjumpto "Options" "calipmatch##options"}{...}


### PR DESCRIPTION
This PR introduces a new Github Action which checks the version number and date in a PR whose base branch (i.e. target branch) is **main**. It checks calipmatch.ado and calipmatch.sthlp.

The version number should be:
* a valid [3-part version](https://semver.org/)
* higher than main

The date should be today's date.

It also updates the date in calipmatch.pkg.
