### PR TITLE
Default distance metric: standardized SSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The help file can be explored interactively in Stata using `help calipmatch`.
 <p>
         <b>calipmatch</b> [<i>if</i>] [<i>in</i>]<b>,</b> <b><u>gen</u></b><b>erate(</b><i>newvar</i><b>)</b> <b><u>case</u></b><b>var(</b><i>varname</i><b>)</b> <b><u>max</u></b><b>matches(</b><i>#</i><b>)</b>
                <b><u>caliperm</u></b><b>atch(</b><i>varlist</i><b>)</b> <b><u>caliperw</u></b><b>idth(</b><i>numlist</i><b>)</b> [<b><u>exactm</u></b><b>atch(</b>
-               <i>varlist</i><b>)</b>]
+               <i>varlist</i><b>)</b><b><u> no</u></b><b>standardize</b>]
 <p>
 <p>
     <i>options</i>                  Description
@@ -44,6 +44,8 @@ The help file can be explored interactively in Stata using `help calipmatch`.
 <p>
     Optional
       <b><u>exactm</u></b><b>atch(</b><i>varlist</i><b>)</b>    list of integer variables to match on exactly
+      <b><u>no</u></b><b>standardize</b>           distance using sum of squares; default is
+                               standardized sum of squares
     -------------------------------------------------------------------------
 <p>
 <p>
@@ -66,11 +68,11 @@ The help file can be explored interactively in Stata using `help calipmatch`.
 <p>
     The cases are processed in random order. For each case, <b>calipmatch</b>
     searches for matching controls. If any valid matches exist, it selects
-    the matching control which minimizes the sum of squared differences
-    across caliper matching variables. If <b>maxmatches(</b><i>#</i><b>)</b>&gt;1, then after
-    completing the search for a first matching control observation for each
-    case, the algorithm will search for a second matching control observation
-    for each case, etc.
+    the matching control which minimizes the standardized sum of squared
+    differences across caliper matching variables. If <b>maxmatches(</b><i>#</i><b>)</b>&gt;1, then
+    after completing the search for a first matching control observation for
+    each case, the algorithm will search for a second matching control
+    observation for each case, etc.
 <p>
 <p>
 <a name="options"></a><b><u>Options</u></b>
@@ -119,6 +121,10 @@ The help file can be explored interactively in Stata using `help calipmatch`.
         This enables speedy exact matching, by ensuring that all values are
         stored as precise integers.
 <p>
+    <b><u>no</u></b><b>standardize</b> calculates distance between cases and controls using the
+        sum of squared differences.  When specified, matches will be
+        sensitive to the scale of caliper variables. This can be used to
+        weight caliper variables.
 <p>
 <a name="saved_results"></a><b><u>Saved results</u></b>
 <p>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The help file can be explored interactively in Stata using `help calipmatch`.
 <p>
         <b>calipmatch</b> [<i>if</i>] [<i>in</i>]<b>,</b> <b><u>gen</u></b><b>erate(</b><i>newvar</i><b>)</b> <b><u>case</u></b><b>var(</b><i>varname</i><b>)</b> <b><u>max</u></b><b>matches(</b><i>#</i><b>)</b>
                <b><u>caliperm</u></b><b>atch(</b><i>varlist</i><b>)</b> <b><u>caliperw</u></b><b>idth(</b><i>numlist</i><b>)</b> [<b><u>exactm</u></b><b>atch(</b>
-               <i>varlist</i><b>)</b><b><u> no</u></b><b>standardize</b>]
+               <i>varlist</i><b>)</b><b> nostandardize</b>]
 <p>
 <p>
     <i>options</i>                  Description
@@ -44,7 +44,7 @@ The help file can be explored interactively in Stata using `help calipmatch`.
 <p>
     Optional
       <b><u>exactm</u></b><b>atch(</b><i>varlist</i><b>)</b>    list of integer variables to match on exactly
-      <b><u>no</u></b><b>standardize</b>           distance using sum of squares; default is
+      <b>nostandardize</b>           distance using sum of squares; default is
                                standardized sum of squares
     -------------------------------------------------------------------------
 <p>
@@ -121,7 +121,7 @@ The help file can be explored interactively in Stata using `help calipmatch`.
         This enables speedy exact matching, by ensuring that all values are
         stored as precise integers.
 <p>
-    <b><u>no</u></b><b>standardize</b> calculates distance between cases and controls using the
+    <b>nostandardize</b> calculates distance between cases and controls using the
         sum of squared differences.  When specified, matches will be
         sensitive to the scale of caliper variables. This can be used to
         weight caliper variables.

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) NOstandardize]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {
@@ -89,7 +89,7 @@ program define calipmatch, sortpreserve rclass
 	
 	if r(no_matches)==0 {
 
-		if ("`nostandardize'"=="") {
+		if "`nostandardize'"=="" {
 			foreach var of varlist `calipermatch' {
 				tempvar std_`var'
 				qui egen `std_`var'' = std(`var') if `touse' == 1
@@ -97,6 +97,7 @@ program define calipmatch, sortpreserve rclass
 			}
 			mata: _calipmatch(boundaries,"`generate'",`maxmatches',"`calipermatch'","`caliperwidth'", "`std_calipermatch'")	
 		}	
+
 		else {
 			mata: _calipmatch(boundaries,"`generate'",`maxmatches',"`calipermatch'","`caliperwidth'")			
 		}

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) NOstandardize]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {
@@ -89,7 +89,7 @@ program define calipmatch, sortpreserve rclass
 	
 	if r(no_matches)==0 {
 
-		if "`nostandardize'"=="" {
+		if "`standardize'"=="" {
 			* Create standardized caliper vars (subtract mean, divide by SD)
 			local i = 0
 			foreach var of varlist `calipermatch' {

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) NOstandardize]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -90,12 +90,18 @@ program define calipmatch, sortpreserve rclass
 	if r(no_matches)==0 {
 
 		if "`nostandardize'"=="" {
+			local i = 0
 			foreach var of varlist `calipermatch' {
 				tempvar std_`var'
-				qui egen `std_`var'' = std(`var') if `touse' == 1
+				local ++i  
+				local width : word `i' of `caliperwidth'
+				qui su `var' if `touse' `in'
+				qui gen `std_`var'' = (`var' - r(mean))/r(sd)
+				local std_`var'_width = `width'/r(sd)
 				local std_calipermatch `std_calipermatch' `std_`var''
+				local std_caliperwidth `std_caliperwidth' `std_`var'_width'
 			}
-			mata: _calipmatch(boundaries,"`generate'",`maxmatches',"`calipermatch'","`caliperwidth'", "`std_calipermatch'")	
+			mata: _calipmatch(boundaries,"`generate'",`maxmatches',"`std_calipermatch'","`std_caliperwidth'")
 		}	
 
 		else {
@@ -145,8 +151,7 @@ set matastrict on
 
 mata:
 
-void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxmatch, string scalar calipvars, string scalar calipwidth,
-| string scalar std_calipvars) {
+void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxmatch, string scalar calipvars, string scalar calipwidth) {
 	// Objective:
 	//		Perform caliper matching using the specified caliper variables and caliper widths, matching each case observation to one or
 	//		many controls. Identify the matches within pre-specified groups, and store a variable containing integers that define a group
@@ -159,24 +164,20 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	//		- maxmatch: a positive integer indicating the maximum number of control obs to match to each case obs
 	//		- calipvars: a list of numeric variables for caliper matching
 	//		- calipwidth: a list of caliper widths, specifying the maximum distance between case and control variables in each calipvar
-	//		- std_calipvars (optional): a list of numeric variables for caliper matching, but standardized by the in-sample mean and s.d.
 	//
 	//	Outputs:
 	//		The values of "genvar" are filled with integers that describe each group of matched cases and controls.
 	//		- r(matchsuccess) is a Stata return matrix tabulating the number of cases successfully matched to {1, ..., maxmatch} controls
-
 	real scalar matchgrp
 	matchgrp = st_varindex(genvar)
 	
 	real rowvector matchvars
 	matchvars = st_varindex(tokens(calipvars))
-
 	real rowvector tolerance
 	tolerance = strtoreal(tokens(calipwidth))
 	
 	real scalar curmatch
 	curmatch = 0
-
 	real scalar highestmatch
 	highestmatch = 0
 	
@@ -194,15 +195,6 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	real rowvector matchvals
 	real matrix controlvals
 	real matrix diffvals
-
-	if (args() > 5) {
-		real rowvector std_matchvars
-		std_matchvars = st_varindex(tokens(std_calipvars))
-		
-		real rowvector std_matchvals
-		real matrix std_controlvals
-		real matrix std_diffvals
-	}
 	
 	for (brow=1; brow<=rows(boundaries); brow++) {
 	
@@ -225,22 +217,16 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 					curmatch = _st_data(caseobs, matchgrp)
 				}
 				
-				// Store matchvar values for the case and for the controls that have not yet been matched, and calculate difference
+				// Store matchvar values for the case and for the controls that have not yet been matched
 				matchvals = st_data(caseobs, matchvars)
 				controlvals = st_data((boundaries[brow,1], boundaries[brow,2]), matchvars) :* editvalue(st_data((boundaries[brow,1], boundaries[brow,2]), matchgrp):==., 0, .)
+				
+				// Store difference in matchvar values if they are within tolerance
 				diffvals = (controlvals :- matchvals)
-
+				diffvals = diffvals :* editvalue(abs(diffvals) :<= tolerance, 0, .)
+				
 				// Find closest control to match
-				if (args() >5) {
-					std_matchvals = st_data(caseobs, std_matchvars)
-					std_controlvals = st_data((boundaries[brow,1], boundaries[brow,2]), std_matchvars) :* editvalue(st_data((boundaries[brow,1], boundaries[brow,2]), matchgrp):==., 0, .)
-					std_diffvals = (std_controlvals :- std_matchvals) :* editvalue(abs(diffvals) :<= tolerance, 0, .)
-					minindex(rowsum(std_diffvals :^2, 1), 1, matchedcontrolindex, minties)
-				}
-				else {
-					diffvals = diffvals :* editvalue(abs(diffvals) :<= tolerance, 0, .)
-					minindex(rowsum(diffvals :^2, 1), 1, matchedcontrolindex, minties)
-				}
+				minindex(rowsum(diffvals :^2, 1), 1, matchedcontrolindex, minties)
 				
 				// If a match is found, store it
 				if (rows(matchedcontrolindex)>0) {
@@ -268,7 +254,6 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	
 	stata("return clear")
 	st_matrix("r(matchsuccess)",matchsuccess)
-
 }
 
 real matrix find_group_boundaries(string scalar grpvars, string scalar casevar, real scalar startobs, real scalar endobs) {

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -57,7 +57,6 @@ program define calipmatch, sortpreserve rclass
 	
 	* Sort into groups for caliper matching, randomizing order of cases and controls
 	tempvar rand
-	set seed 4585239 // TO REMOVE! 
 	gen float `rand'=runiform()
 	sort `touse' `exactmatch' `casevar' `rand'
 	

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -9,7 +9,6 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 */
 
 * Why did I include a formal license? Jeff Atwood gives good reasons: https://blog.codinghorror.com/pick-a-license-any-license/
-
 program define calipmatch, sortpreserve rclass
 	version 13.0
 	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) NOstandardize]
@@ -58,6 +57,7 @@ program define calipmatch, sortpreserve rclass
 	
 	* Sort into groups for caliper matching, randomizing order of cases and controls
 	tempvar rand
+	set seed 4585239 /// TO REMOVE! 
 	gen float `rand'=runiform()
 	sort `touse' `exactmatch' `casevar' `rand'
 	

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -94,14 +94,13 @@ program define calipmatch, sortpreserve rclass
 			local i = 0
 			foreach var of varlist `calipermatch' {
 				local ++i
-				tempvar std_`var'
-				local width : word `i' of `caliperwidth'
 
+				tempvar std_`var'
 				qui sum `var' in `=_N-`insample_total'+1'/`=_N'
 				qui gen `std_`var'' = (`var' - r(mean)) / r(sd) in `=_N-`insample_total'+1'/`=_N'
 
 				local std_calipermatch `std_calipermatch' `std_`var''
-				local std_caliperwidth `std_caliperwidth' `=`width'/r(sd)'
+				local std_caliperwidth `std_caliperwidth' `=`: word `i' of `caliperwidth'' / r(sd)'
 			}
 
 			mata: _calipmatch(boundaries,"`generate'",`maxmatches',"`std_calipermatch'","`std_caliperwidth'")

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -158,6 +158,7 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	//		- maxmatch: a positive integer indicating the maximum number of control obs to match to each case obs
 	//		- calipvars: a list of numeric variables for caliper matching
 	//		- calipwidth: a list of caliper widths, specifying the maximum distance between case and control variables in each calipvar
+	//		- std_calipvars (optional): a list of numeric variables for caliper matching, but standardized by the in-sample mean and s.d.
 	//
 	//	Outputs:
 	//		The values of "genvar" are filled with integers that describe each group of matched cases and controls.

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [nostandard]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandard]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -168,16 +168,19 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	//	Outputs:
 	//		The values of "genvar" are filled with integers that describe each group of matched cases and controls.
 	//		- r(matchsuccess) is a Stata return matrix tabulating the number of cases successfully matched to {1, ..., maxmatch} controls
+	
 	real scalar matchgrp
 	matchgrp = st_varindex(genvar)
 	
 	real rowvector matchvars
 	matchvars = st_varindex(tokens(calipvars))
+	
 	real rowvector tolerance
 	tolerance = strtoreal(tokens(calipwidth))
 	
 	real scalar curmatch
 	curmatch = 0
+	
 	real scalar highestmatch
 	highestmatch = 0
 	
@@ -254,6 +257,7 @@ void _calipmatch(real matrix boundaries, string scalar genvar, real scalar maxma
 	
 	stata("return clear")
 	st_matrix("r(matchsuccess)",matchsuccess)
+	
 }
 
 real matrix find_group_boundaries(string scalar grpvars, string scalar casevar, real scalar startobs, real scalar endobs) {

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -57,7 +57,7 @@ program define calipmatch, sortpreserve rclass
 	
 	* Sort into groups for caliper matching, randomizing order of cases and controls
 	tempvar rand
-	set seed 4585239 /// TO REMOVE! 
+	set seed 4585239 // TO REMOVE! 
 	gen float `rand'=runiform()
 	sort `touse' `exactmatch' `casevar' `rand'
 	

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandard]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {
@@ -89,7 +89,7 @@ program define calipmatch, sortpreserve rclass
 	
 	if r(no_matches)==0 {
 
-		if ("`nostandard'"=="") {
+		if ("`nostandardize'"=="") {
 			foreach var of varlist `calipermatch' {
 				tempvar std_`var'
 				qui egen `std_`var'' = std(`var') if `touse' == 1

--- a/calipmatch.ado
+++ b/calipmatch.ado
@@ -12,7 +12,7 @@ human-readable summary can be accessed at http://creativecommons.org/publicdomai
 
 program define calipmatch, sortpreserve rclass
 	version 13.0
-	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [brief]
+	syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [nostandard]
 		
 	* Verify there are same number of caliper vars as caliper widths
 	if (`: word count `calipermatch'' != `: word count `caliperwidth'') {
@@ -89,7 +89,7 @@ program define calipmatch, sortpreserve rclass
 	
 	if r(no_matches)==0 {
 
-		if ("`brief'"=="") {
+		if ("`nostandard'"=="") {
 			foreach var of varlist `calipermatch' {
 				tempvar std_`var'
 				qui egen `std_`var'' = std(`var') if `touse' == 1

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -44,7 +44,7 @@ matching{p_end}
 
 {syntab :Optional}
 {synopt :{opth exactm:atch(varlist)}}list of integer variables to match on exactly{p_end}
-{synopt :{opth nostandard(varlist)}} distance using sum of squares; default is standardized sum of squares {p_end}
+{synopt :{bf:nostandard}} distance using sum of squares; default is standardized sum of squares {p_end}
 {synoptline}
 
 
@@ -116,7 +116,7 @@ matching variables, they must also have identical values for every exact matchin
 {it:int} or {it:long}. This enables speedy exact matching, by ensuring that
 all values are stored as precise integers.
 
-{phang}{opth nostandard} calculates distance between cases and controls using the sum of squares.
+{phang}{bf:nostandard} calculates distance between cases and controls using the sum of squares.
 When specified, matches will be sensitive to the scale of caliper variables. This can be used to weight caliper variables.
 
 {marker saved_results}{...}

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -24,7 +24,7 @@ Create a variable indicating groups of matched cases and controls
 {opt max:matches(#)}
 {opth caliperm:atch(varlist)}
 {opth caliperw:idth(numlist)}
-[{opth exactm:atch(varlist)} {bf: {ul: no}standardize}]
+[{opth exactm:atch(varlist)} {bf: nostandardize}]
 
 
 {synoptset 23 tabbed}{...}
@@ -44,7 +44,7 @@ matching{p_end}
 
 {syntab :Optional}
 {synopt :{opth exactm:atch(varlist)}}list of integer variables to match on exactly{p_end}
-{synopt :{bf: {ul:no}standardize}} distance using sum of squares; default is standardized sum of squares {p_end}
+{synopt :{bf: nostandardize}} distance using sum of squares; default is standardized sum of squares {p_end}
 {synoptline}
 
 
@@ -116,7 +116,7 @@ matching variables, they must also have identical values for every exact matchin
 {it:int} or {it:long}. This enables speedy exact matching, by ensuring that
 all values are stored as precise integers.
 
-{phang}{bf: {ul:no}standardize} calculates distance between cases and controls using the sum of squared differences.
+{phang}{bf: nostandardize} calculates distance between cases and controls using the sum of squared differences.
 When specified, matches will be sensitive to the scale of caliper variables. This can be used to weight caliper variables.
 
 {marker saved_results}{...}

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -24,7 +24,7 @@ Create a variable indicating groups of matched cases and controls
 {opt max:matches(#)}
 {opth caliperm:atch(varlist)}
 {opth caliperw:idth(numlist)}
-[{opth exactm:atch(varlist)} {bf: nostandardize}]
+[{opth exactm:atch(varlist)} {bf: {ul: no}standardize}]
 
 
 {synoptset 23 tabbed}{...}
@@ -44,7 +44,7 @@ matching{p_end}
 
 {syntab :Optional}
 {synopt :{opth exactm:atch(varlist)}}list of integer variables to match on exactly{p_end}
-{synopt :{bf:nostandardize}} distance using sum of squares; default is standardized sum of squares {p_end}
+{synopt :{bf: {ul:no}standardize}} distance using sum of squares; default is standardized sum of squares {p_end}
 {synoptline}
 
 
@@ -116,7 +116,7 @@ matching variables, they must also have identical values for every exact matchin
 {it:int} or {it:long}. This enables speedy exact matching, by ensuring that
 all values are stored as precise integers.
 
-{phang}{bf:nostandardize} calculates distance between cases and controls using the sum of squared differences.
+{phang}{bf: {ul:no}standardize} calculates distance between cases and controls using the sum of squared differences.
 When specified, matches will be sensitive to the scale of caliper variables. This can be used to weight caliper variables.
 
 {marker saved_results}{...}

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -44,6 +44,7 @@ matching{p_end}
 
 {syntab :Optional}
 {synopt :{opth exactm:atch(varlist)}}list of integer variables to match on exactly{p_end}
+{synopt :{opth nostandard(varlist)}} distance using sum of squares; default is standardized sum of squares {p_end}
 {synoptline}
 
 
@@ -67,7 +68,7 @@ variables when multiple valid matches exist.
 
 {pstd}
 The cases are processed in random order. For each case, {cmd:calipmatch} searches for matching controls. If
-any valid matches exist, it selects the matching control which minimizes the sum of squared differences across
+any valid matches exist, it selects the matching control which minimizes the standardized sum of squared differences across
 caliper matching variables. If {opt maxmatches(#)}>1, then after completing the search for a first matching
 control observation for each case, the algorithm will search for a second matching control observation for
 each case, etc.
@@ -115,6 +116,8 @@ matching variables, they must also have identical values for every exact matchin
 {it:int} or {it:long}. This enables speedy exact matching, by ensuring that
 all values are stored as precise integers.
 
+{phang}{opth nostandard} calculates distance between cases and controls using the sum of squares.
+When specified, matches will be sensitive to the scale of caliper variables. This can be used to weight caliper variables.
 
 {marker saved_results}{...}
 {title:Saved results}

--- a/calipmatch.sthlp
+++ b/calipmatch.sthlp
@@ -24,7 +24,7 @@ Create a variable indicating groups of matched cases and controls
 {opt max:matches(#)}
 {opth caliperm:atch(varlist)}
 {opth caliperw:idth(numlist)}
-[{opth exactm:atch(varlist)}]
+[{opth exactm:atch(varlist)} {bf: nostandardize}]
 
 
 {synoptset 23 tabbed}{...}
@@ -44,7 +44,7 @@ matching{p_end}
 
 {syntab :Optional}
 {synopt :{opth exactm:atch(varlist)}}list of integer variables to match on exactly{p_end}
-{synopt :{bf:nostandard}} distance using sum of squares; default is standardized sum of squares {p_end}
+{synopt :{bf:nostandardize}} distance using sum of squares; default is standardized sum of squares {p_end}
 {synoptline}
 
 
@@ -116,7 +116,7 @@ matching variables, they must also have identical values for every exact matchin
 {it:int} or {it:long}. This enables speedy exact matching, by ensuring that
 all values are stored as precise integers.
 
-{phang}{bf:nostandard} calculates distance between cases and controls using the sum of squares.
+{phang}{bf:nostandardize} calculates distance between cases and controls using the sum of squared differences.
 When specified, matches will be sensitive to the scale of caliper variables. This can be used to weight caliper variables.
 
 {marker saved_results}{...}

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -369,6 +369,25 @@ assert matchgroup == . in 3/5
 
 keep case income_percentile age
 
+* matches minimize sum of normalized squares
+replace age = 1000*age
+egen std_income_percentile = std(income_percentile)
+egen std_age = std(age)
+
+gen float sse = (income_percentile - income_percentile[1])^2 + (age - age[1])^2
+gen float std_sse = (std_income_percentile - std_income_percentile[1])^2 + (std_age - std_age[1])^2
+
+test_calipmatch, gen(matchgroup) case(case) maxmatches(1) ///
+	calipermatch(income_percentile age) caliperwidth(100 100000)
+
+sum std_sse if case==0, meanonly
+assert cond(_n==2, std_sse==r(min), std_sse!=r(min))  // test that obs 2 is global min
+
+assert matchgroup == 1 in 2  // test that obs 2 is matched
+assert matchgroup == . in 3/5
+
+keep case income_percentile age
+
 *----------------------------------------------------------------------------
 
 di "Successfully completed all tests."

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -9,7 +9,7 @@ program define test_calipmatch
 	if (_rc==0) {
 	
 		* Assign arguments to locals using the same syntax as calipmatch
-		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)]
+		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [brief]
 	
 		* Store returned objects
 		local cases_total = r(cases_total)

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -9,7 +9,7 @@ program define test_calipmatch
 	if (_rc==0) {
 	
 		* Assign arguments to locals using the same syntax as calipmatch
-		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) NOstandardize]
+		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
 	
 		* Store returned objects
 		local cases_total = r(cases_total)

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -9,7 +9,7 @@ program define test_calipmatch
 	if (_rc==0) {
 	
 		* Assign arguments to locals using the same syntax as calipmatch
-		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandard]
+		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandardize]
 	
 		* Store returned objects
 		local cases_total = r(cases_total)

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -400,37 +400,19 @@ gen byte case=(_n<=200)
 gen byte income_percentile=ceil(runiform() * 100)
 gen byte age = 44 + ceil(runiform()*17)
 
+set seed 4585239
+set sortseed 789045789
+
 test_calipmatch, gen(matchgroup_1) case(case) maxmatches(1) ///
 	calipermatch(income_percentile age) caliperwidth(5 3) 
 
-keep case income_percentile age matchgroup_1
+drop casecount matched_case control matched_controls
+
+set seed 4585239
+set sortseed 789045789
 
 test_calipmatch, gen(matchgroup_2) case(case) maxmatches(1) ///
-	calipermatch(income_percentile age) caliperwidth(5 3) nostandardize
-
-keep case income_percentile age matchgroup_1 matchgroup_2
-
-gen int days_over_44 = (age-44)*365
-
-test_calipmatch, gen(matchgroup_3) case(case) maxmatches(1) ///
-	calipermatch(income_percentile days_over_44) caliperwidth(5 1095)  
-
-keep case income_percentile age days_over_44 matchgroup_1 matchgroup_2 matchgroup_3
-
-test_calipmatch, gen(matchgroup_4) case(case) maxmatches(1) ///
-	calipermatch(income_percentile days_over_44) caliperwidth(5 1095) nostandardize
-
-keep case income_percentile age days_over_44 matchgroup_1 matchgroup_2 matchgroup_3 matchgroup_4
-
-gen match_diffs_std = abs(matchgroup_1 - matchgroup_3)
-su match_diffs_std, meanonly
-assert r(max) == 0
-
-gen match_diffs = abs(matchgroup_2 - matchgroup_4)
-su match_diffs, meanonly 
-assert r(max) != 0
-
-keep case income_percentile age
+	calipermatch(income_percentile age) caliperwidth(5 3)
 
 *----------------------------------------------------------------------------
 

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -415,6 +415,32 @@ set sortseed 789045789
 test_calipmatch, gen(matchgroup_2) case(case) maxmatches(1) ///
 	calipermatch(income_percentile days_over_44) caliperwidth(5 1095)
 
+drop casecount matched_case control matched_controls
+
+gen match_diffs_std = abs(matchgroup_1 - matchgroup_2)
+su match_diffs_std, meanonly
+assert r(max) == 0
+
+set seed 4585239
+set sortseed 789045789
+
+test_calipmatch, gen(matchgroup_3) case(case) maxmatches(1) ///
+	calipermatch(income_percentile age) caliperwidth(5 3) nostandardize
+
+drop casecount matched_case control matched_controls
+
+set seed 4585239
+set sortseed 789045789
+
+test_calipmatch, gen(matchgroup_4) case(case) maxmatches(1) ///
+	calipermatch(income_percentile days_over_44) caliperwidth(5 1095) nostandardize
+
+gen match_diffs = abs(matchgroup_3 - matchgroup_4)
+su match_diffs, meanonly 
+assert r(max) != 0
+
+keep case income_percentile age 
+
 *----------------------------------------------------------------------------
 
 di "Successfully completed all tests."

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -387,6 +387,50 @@ assert matchgroup == . in 4/5
 
 keep case income_percentile age_days
 
+*============================================================================
+* New dataset: one caliper matching variable, with different scales
+*============================================================================
+
+clear
+set obs 2000
+
+gen byte case=(_n<=200)
+
+gen byte income_percentile=ceil(runiform() * 100)
+gen byte age = 44 + ceil(runiform()*17)
+
+test_calipmatch, gen(matchgroup_1) case(case) maxmatches(1) ///
+	calipermatch(income_percentile age) caliperwidth(5 3) 
+
+keep case income_percentile age matchgroup_1
+
+test_calipmatch, gen(matchgroup_2) case(case) maxmatches(1) ///
+	calipermatch(income_percentile age) caliperwidth(5 3) nostandardize
+
+keep case income_percentile age matchgroup_1 matchgroup_2
+
+gen int days_over_44 = (age-44)*365
+
+test_calipmatch, gen(matchgroup_3) case(case) maxmatches(1) ///
+	calipermatch(income_percentile days_over_44) caliperwidth(5 1095)  
+
+keep case income_percentile age days_over_44 matchgroup_1 matchgroup_2 matchgroup_3
+
+test_calipmatch, gen(matchgroup_4) case(case) maxmatches(1) ///
+	calipermatch(income_percentile days_over_44) caliperwidth(5 1095) nostandardize
+
+keep case income_percentile age days_over_44 matchgroup_1 matchgroup_2 matchgroup_3 matchgroup_4
+
+gen std_diff = abs(matchgroup_1 - matchgroup_3)
+su std_diff, meanonly
+assert r(max) == 0
+
+gen diff = abs(matchgroup_2 - matchgroup_4)
+su diff, meanonly 
+assert r(max) != 0
+
+keep case income_percentile age
+
 *----------------------------------------------------------------------------
 
 di "Successfully completed all tests."

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -388,14 +388,9 @@ assert matchgroup == . in 4/5
 keep case income_percentile age_days
 
 *============================================================================
-* New dataset: two caliper matching variables, with different scales
+* New dataset: two caliper matching variables, with scaling and a shift
 *============================================================================
 
-*----------------------------------------------------------------------------
-* Valid inputs, test performance of matching algorithm 
-*----------------------------------------------------------------------------
-
-* matches are scale invariant
 clear
 set obs 2000
 
@@ -405,6 +400,11 @@ gen byte income_percentile=ceil(runiform() * 100)
 gen byte age = 44 + ceil(runiform()*17)
 gen int days_over_44 = (age - 44)*365
 
+*----------------------------------------------------------------------------
+* Valid inputs, test performance of matching algorithm 
+*----------------------------------------------------------------------------
+
+* matches are scale and shift invariant
 set seed 4585239
 set sortseed 789045789
 
@@ -425,7 +425,7 @@ gen match_diffs_std = abs(matchgroup_1 - matchgroup_2)
 su match_diffs_std, meanonly
 assert r(max) == 0
 
-* matches are scale dependent when nostandardize is specified
+* matches are scale and shift dependent when nostandardize is specified
 set seed 4585239
 set sortseed 789045789
 

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -9,7 +9,7 @@ program define test_calipmatch
 	if (_rc==0) {
 	
 		* Assign arguments to locals using the same syntax as calipmatch
-		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [brief]
+		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [nostandard]
 	
 		* Store returned objects
 		local cases_total = r(cases_total)

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -399,6 +399,7 @@ gen byte case=(_n<=200)
 
 gen byte income_percentile=ceil(runiform() * 100)
 gen byte age = 44 + ceil(runiform()*17)
+gen int days_over_44 = (age - 44)*365
 
 set seed 4585239
 set sortseed 789045789
@@ -412,7 +413,7 @@ set seed 4585239
 set sortseed 789045789
 
 test_calipmatch, gen(matchgroup_2) case(case) maxmatches(1) ///
-	calipermatch(income_percentile age) caliperwidth(5 3)
+	calipermatch(income_percentile days_over_44) caliperwidth(5 1095)
 
 *----------------------------------------------------------------------------
 

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -388,9 +388,10 @@ assert matchgroup == . in 4/5
 keep case income_percentile age_days
 
 *============================================================================
-* New dataset: one caliper matching variable, with different scales
+* New dataset: two caliper matching variables, with different scales
 *============================================================================
 
+* matches are scale invariant
 clear
 set obs 2000
 
@@ -421,12 +422,12 @@ test_calipmatch, gen(matchgroup_4) case(case) maxmatches(1) ///
 
 keep case income_percentile age days_over_44 matchgroup_1 matchgroup_2 matchgroup_3 matchgroup_4
 
-gen std_diff = abs(matchgroup_1 - matchgroup_3)
-su std_diff, meanonly
+gen match_diffs_std = abs(matchgroup_1 - matchgroup_3)
+su match_diffs_std, meanonly
 assert r(max) == 0
 
-gen diff = abs(matchgroup_2 - matchgroup_4)
-su diff, meanonly 
+gen match_diffs = abs(matchgroup_2 - matchgroup_4)
+su match_diffs, meanonly 
 assert r(max) != 0
 
 keep case income_percentile age

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -9,7 +9,7 @@ program define test_calipmatch
 	if (_rc==0) {
 	
 		* Assign arguments to locals using the same syntax as calipmatch
-		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist)] [nostandard]
+		syntax [if] [in], GENerate(name) CASEvar(varname numeric) MAXmatches(numlist integer >0 max=1) CALIPERMatch(varlist numeric) CALIPERWidth(numlist >0) [EXACTmatch(varlist) nostandard]
 	
 		* Store returned objects
 		local cases_total = r(cases_total)

--- a/test_calipmatch.do
+++ b/test_calipmatch.do
@@ -391,6 +391,10 @@ keep case income_percentile age_days
 * New dataset: two caliper matching variables, with different scales
 *============================================================================
 
+*----------------------------------------------------------------------------
+* Valid inputs, test performance of matching algorithm 
+*----------------------------------------------------------------------------
+
 * matches are scale invariant
 clear
 set obs 2000
@@ -421,6 +425,7 @@ gen match_diffs_std = abs(matchgroup_1 - matchgroup_2)
 su match_diffs_std, meanonly
 assert r(max) == 0
 
+* matches are scale dependent when nostandardize is specified
 set seed 4585239
 set sortseed 789045789
 


### PR DESCRIPTION
Add: minimize standardized sum of squares as default metric, with option to use sum of squares 
Add: Test standardized sse is minimized and test sse is minimized when option is specified
Update: Help file to reflect above